### PR TITLE
Pfem compatibility update

### DIFF
--- a/cupydo/interfaces/Pfem.py
+++ b/cupydo/interfaces/Pfem.py
@@ -195,7 +195,7 @@ class Pfem(FluidSolver):
         if nt%self.pfem.scheme.savefreq==0:
             self.pfem.scheme.archive()
         if not self.pfem.gui==None:
-            self.pfem.scheme.vizu(self.pfem.scheme.u,self.pfem.scheme.v,self.pfem.scheme.p,self.pfem.scheme.matID)
+            self.pfem.scheme.vizu()
         
     def initRealTimeData(self):
         """

--- a/cupydo/interfaces/Pfem.py
+++ b/cupydo/interfaces/Pfem.py
@@ -74,17 +74,15 @@ class Pfem(FluidSolver):
         self.nPhysicalNodes = self.nNodes - self.nHaloNode                        # numbers of nodes at the f/s interface (physical)
         
         # Pfem scheme initialization
-        self.V = self.pfem.w.DoubleVector()
-        self.V0 = self.pfem.w.DoubleVector()
-        self.u = self.pfem.w.DoubleVector()
-        self.v = self.pfem.w.DoubleVector()
-        self.p = self.pfem.w.DoubleVector()
-        self.velocity = self.pfem.w.DoubleVector()
-        self.matID = self.pfem.w.IntVector()
+        #self.u = self.pfem.w.DoubleVector()
+        #self.v = self.pfem.w.DoubleVector()
+        #self.p = self.pfem.w.DoubleVector()
+        #self.velocity = self.pfem.w.DoubleVector()
+        #self.matID = self.pfem.w.IntVector()
         
         self.pfem.scheme.t = 0.
         self.pfem.scheme.dt = dt
-        self.pfem.scheme.init(self.V,self.V0,self.u,self.v,self.p,self.velocity,self.matID)
+        self.pfem.scheme.init()
         # [AC] I moved the following 3 lines from the test cases definition to the interface
         self.pfem.scheme.nthreads = nthreads
         if nogui:
@@ -103,8 +101,8 @@ class Pfem(FluidSolver):
         calculates one increment from t1 to t2.
         """
         
-        self.pfem.scheme.setNextStep(self.V,self.V0,self.u,self.v,self.p,self.velocity,self.matID)
-        self.runOK = self.pfem.scheme.runOneTimeStep(self.V,self.V0,self.u,self.v,self.p,self.velocity)
+        self.pfem.scheme.setNextStep()
+        self.runOK = self.pfem.scheme.runOneTimeStep()
         
         self.__setCurrentState()
     
@@ -180,14 +178,15 @@ class Pfem(FluidSolver):
     def update(self, dt):
         self.pfem.scheme.t+=dt
         self.pfem.scheme.nt+=1
-        self.pfem.scheme.updateSolutionVectors(self.V,self.V0,self.u,self.v,self.p,self.velocity)
-        self.pfem.scheme.updateMatIDVector(self.matID)
-        
+        self.pfem.scheme.updateSolutionVectors()
+        self.pfem.scheme.updateMatIDVector()
+        #self.u = self.pfem.scheme.u
+        #self.v = self.pfem.scheme.v
         
         #---
         for i in range(len(self.vnods)):
-            displ_x = self.displ_x_Nm1[i] + self.u[self.vnods[i].rowU]*dt
-            displ_y = self.displ_y_Nm1[i] + self.v[self.vnods[i].rowU]*dt
+            displ_x = self.displ_x_Nm1[i] + self.pfem.scheme.u[self.vnods[i].rowU]*dt
+            displ_y = self.displ_y_Nm1[i] + self.pfem.scheme.v[self.vnods[i].rowU]*dt
             self.displ_x_Nm1[i] = displ_x
             self.displ_y_Nm1[i] = displ_y
         # ---
@@ -196,7 +195,7 @@ class Pfem(FluidSolver):
         if nt%self.pfem.scheme.savefreq==0:
             self.pfem.scheme.archive()
         if not self.pfem.gui==None:
-            self.pfem.scheme.vizu(self.u,self.v,self.p,self.matID)
+            self.pfem.scheme.vizu(self.pfem.scheme.u,self.pfem.scheme.v,self.pfem.scheme.p,self.pfem.scheme.matID)
         
     def initRealTimeData(self):
         """
@@ -244,7 +243,7 @@ class Pfem(FluidSolver):
     
     def remeshing(self):
         self.pfem.scheme.remeshing()
-        self.pfem.scheme.updateData()
+        self.pfem.scheme.updateNodalRefValues()
     
     def exit(self):
         """

--- a/cupydo/interpolator.py
+++ b/cupydo/interpolator.py
@@ -250,24 +250,54 @@ class InterfaceInterpolator(ccupydo.CInterpolator):
                         for iDim in range(fluidInterfaceData.nDim):
                             sendBuffHalo[key].append(fluidInterfaceData_array_recon[iDim][globalIndex])
                     iTagSend = 1
-                    for iDim in range(fluidInterfaceData.nDim):
-                        self.mpiComm.Isend(sendBuff[iDim], dest=iProc, tag = iTagSend)
-                        iTagSend += 1
-                    #self.mpiComm.send(sendBuffHalo, dest = iProc, tag=iTagSend)
-                    sendBuffHalo_key = np.array(sendBuffHalo.keys())
-                    sendBuffHalo_values = np.empty((sendBuffHalo_key.size, 3),dtype=float)
-                    for ii in range(sendBuffHalo_key.size):
-                        sendBuffHalo_values[ii] = np.array(sendBuffHalo[sendBuffHalo_key[ii]])
-                    self.mpiComm.Isend(np.array(sendBuffHalo_key.size), dest=iProc, tag=101)
-                    self.mpiComm.Isend(sendBuffHalo_key, dest=iProc, tag=102)
-                    self.mpiComm.Isend(sendBuffHalo_values, dest=iProc, tag=103)
-            if self.myid in self.manager.getFluidInterfaceProcessors():
+                    if iProc == 0: # In the master node use non-blocking and immediately receive them
+                        for iDim in range(fluidInterfaceData.nDim):
+                            self.mpiComm.Isend(sendBuff[iDim], dest=iProc, tag = iTagSend)
+                            iTagSend += 1
+                        sendBuffHalo_key = np.array(list(sendBuffHalo.keys()))
+                        sendBuffHalo_values = np.empty((sendBuffHalo_key.size, 3),dtype=float)
+                        for ii in range(sendBuffHalo_key.size):
+                            sendBuffHalo_values[ii] = np.array(sendBuffHalo[sendBuffHalo_key[ii]])
+                        self.mpiComm.Isend(np.array(sendBuffHalo_key.size), dest=iProc, tag=101)
+                        self.mpiComm.Isend(sendBuffHalo_key, dest=iProc, tag=102)
+                        self.mpiComm.Isend(sendBuffHalo_values, dest=iProc, tag=103)
+                        localFluidInterfaceData_array = []
+                        iTagRec = 1
+                        for iDim in range(fluidInterfaceData.nDim):
+                            local_array = np.zeros(self.nf_loc)
+                            self.mpiComm.Recv(local_array, source=0, tag=iTagRec)
+                            localFluidInterfaceData_array.append(local_array)
+                            iTagRec += 1
+                        nHaloNodesRcv = np.empty(1, dtype=int)
+                        req = self.mpiComm.Irecv(nHaloNodesRcv, source=0, tag=101)
+                        req.Wait()
+                        rcvBuffHalo_keyBuff = np.empty(nHaloNodesRcv[0], dtype=int)
+                        req = self.mpiComm.Irecv(rcvBuffHalo_keyBuff, source=0, tag=102)
+                        req.Wait()
+                        rcvBuffHalo_values = np.empty((nHaloNodesRcv[0],3), dtype=float)
+                        req = self.mpiComm.Irecv(rcvBuffHalo_values, source=0, tag=103)
+                        req.Wait()
+                        for ii in range(len(rcvBuffHalo_keyBuff)):
+                            haloNodesData_bis[rcvBuffHalo_keyBuff[ii]] = list(rcvBuffHalo_values[ii])
+                        haloNodesData = haloNodesData_bis
+                    else: # In other processors it's ok to send the buffers with blocking comms
+                        for iDim in range(fluidInterfaceData.nDim):
+                            self.mpiComm.Send(sendBuff[iDim], dest=iProc, tag = iTagSend)
+                            iTagSend += 1
+                        #self.mpiComm.send(sendBuffHalo, dest = iProc, tag=iTagSend)
+                        sendBuffHalo_key = np.array(list(sendBuffHalo.keys()))
+                        sendBuffHalo_values = np.empty((sendBuffHalo_key.size, 3),dtype=float)
+                        for ii in range(sendBuffHalo_key.size):
+                            sendBuffHalo_values[ii] = np.array(sendBuffHalo[sendBuffHalo_key[ii]])
+                        self.mpiComm.Send(np.array(sendBuffHalo_key.size), dest=iProc, tag=101)
+                        self.mpiComm.Send(sendBuffHalo_key, dest=iProc, tag=102)
+                        self.mpiComm.Send(sendBuffHalo_values, dest=iProc, tag=103)
+            elif self.myid in self.manager.getFluidInterfaceProcessors():
                 localFluidInterfaceData_array = []
                 iTagRec = 1
                 for iDim in range(fluidInterfaceData.nDim):
                     local_array = np.zeros(self.nf_loc)
-                    req = self.mpiComm.Irecv(local_array, source=0, tag=iTagRec)
-                    req.Wait()
+                    self.mpiComm.Recv(local_array, source=0, tag=iTagRec)
                     localFluidInterfaceData_array.append(local_array)
                     iTagRec += 1
                 #haloNodesData = self.mpiComm.recv(source=0, tag=iTagRec)
@@ -275,11 +305,9 @@ class InterfaceInterpolator(ccupydo.CInterpolator):
                 req = self.mpiComm.Irecv(nHaloNodesRcv, source=0, tag=101)
                 req.Wait()
                 rcvBuffHalo_keyBuff = np.empty(nHaloNodesRcv[0], dtype=int)
-                req = self.mpiComm.Irecv(rcvBuffHalo_keyBuff, source=0, tag=102)
-                req.Wait()
+                self.mpiComm.Recv(rcvBuffHalo_keyBuff, source=0, tag=102)
                 rcvBuffHalo_values = np.empty((nHaloNodesRcv[0],3), dtype=float)
-                req = self.mpiComm.Irecv(rcvBuffHalo_values, source=0, tag=103)
-                req.Wait()
+                self.mpiComm.Recv(rcvBuffHalo_values, source=0, tag=103)
                 for ii in range(len(rcvBuffHalo_keyBuff)):
                     haloNodesData_bis[rcvBuffHalo_keyBuff[ii]] = list(rcvBuffHalo_values[ii])
                 haloNodesData = haloNodesData_bis
@@ -404,6 +432,7 @@ class InterfaceInterpolator(ccupydo.CInterpolator):
 
         if self.mpiComm != None:
             (localFluidInterfaceDisplacement, haloNodesDisplacements) = self.redistributeDataToFluidSolver(self.fluidInterfaceDisplacement)
+#            mpiBarrier(self.mpiComm)
             if self.myid in self.manager.getFluidInterfaceProcessors():
                 self.FluidSolver.applyNodalDisplacements(localFluidInterfaceDisplacement[0], localFluidInterfaceDisplacement[1], localFluidInterfaceDisplacement[2], localFluidInterfaceDisplacement[0], localFluidInterfaceDisplacement[1], localFluidInterfaceDisplacement[2], haloNodesDisplacements, time)
         else:

--- a/cupydo/utilities.py
+++ b/cupydo/utilities.py
@@ -154,7 +154,7 @@ def setDirs(fpath):
         if size > 1: # send sync to slaves
                 for i in range(1, size):
                     comm.send(1, dest=i, tag=11)
-        comm.barrier()
+                comm.barrier()
     # block slave processes
     else:
         comm.barrier()

--- a/cupydo/utilities.py
+++ b/cupydo/utilities.py
@@ -154,6 +154,7 @@ def setDirs(fpath):
         if size > 1: # send sync to slaves
                 for i in range(1, size):
                     comm.send(1, dest=i, tag=11)
+        comm.barrier()
     # block slave processes
     else:
         comm.barrier()

--- a/tests/PFEM_Metafor/bird/impact_fluid.py
+++ b/tests/PFEM_Metafor/bird/impact_fluid.py
@@ -86,7 +86,7 @@ def getPfem():
     convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 13 # fsi boundary
 

--- a/tests/PFEM_Metafor/bird/impactaxi_fluid.py
+++ b/tests/PFEM_Metafor/bird/impactaxi_fluid.py
@@ -85,7 +85,7 @@ def getPfem():
     convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 13 # fsi boundary no
 

--- a/tests/PFEM_Metafor/bird/lsdyna_fluid.py
+++ b/tests/PFEM_Metafor/bird/lsdyna_fluid.py
@@ -85,7 +85,7 @@ def getPfem():
     convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 15 # fsi boundary
 

--- a/tests/PFEM_Metafor/static/cylinder_fluid.py
+++ b/tests/PFEM_Metafor/static/cylinder_fluid.py
@@ -78,7 +78,7 @@ def getPfem():
     convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 9
     msh.ptags[9].name = "Cylinder"

--- a/tests/PFEM_Metafor/wcolumn/elasticgate/rho1100_fluid.py
+++ b/tests/PFEM_Metafor/wcolumn/elasticgate/rho1100_fluid.py
@@ -80,7 +80,7 @@ def getPfem():
     convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 17 # fsi boundary
 

--- a/tests/PFEM_Metafor/wcolumn/obstacle/matching_fluid.py
+++ b/tests/PFEM_Metafor/wcolumn/obstacle/matching_fluid.py
@@ -80,7 +80,7 @@ def getPfem():
     convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 17 # fsi boundary
 

--- a/tests/PFEM_Metafor/wcolumn/obstacle/nonmatching_fluid.py
+++ b/tests/PFEM_Metafor/wcolumn/obstacle/nonmatching_fluid.py
@@ -81,7 +81,7 @@ def getPfem():
     convCriterion = w.PositionIncrementCriterion(msh, pbl, toll)
     nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)
 
-    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
+    scheme = w.TimeIntegration(msh, pbl, solScheme)
 
     bndno = 17 # fsi boundary
 


### PR DESCRIPTION
Two things have changed in PFEM that affect CUPyDO:

### 1. solution vectors

This concerns changes in the interface/Pfem.py file. The solution vectors `u`, `v`, `p`, and `MatID `have become members of PFEM's `TimeIntegration `class and therefore do not need to be passed as arguments to many of the functions of the same class. This includes the functions

- `init()`
- `setNextTimeStep()`
- `runOneTimeStep()`
- `vizu()`
- several `update_xxx()` functions

Whenever CUPyDO needs to access these, it can directly read and write using `self.scheme.u` etc., where scheme is the local name given to the instance of the `TimeIntegration `class. This way, no duplication of these vectors is necessary, making the local vectors self.u etc. obsolete

### 2. `SolutionScheme `vs. `NonLinearAlgorithm`

This concerns all pfem input files (xxx_fluid.py). Due to a [restructuring](https://gitlab.uliege.be/am-dept/PFEM/merge_requests/52) of how the pfem classes `SolutionScheme `and `NonLinearAlgorithm `relate to each other, `TimeIntegration `is now initialized with a `SolutionScheme  `object, where a `NonLinearAlgorithm `object was before.

before:
```
    solScheme = w.SchemeMonolithicPSPG(msh, pbl)
    convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
    nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)

    scheme = w.TimeIntegration(msh, pbl, nonLinAlgo)
```

after:
```
    solScheme = w.SchemeMonolithicPSPG(msh, pbl)
    convCriterion = w.ForcesBalanceNormedBodyForceCriterion(msh, pbl, toll)
    nonLinAlgo = w.PicardAlgorithm(solScheme, convCriterion, nItMax)

    scheme = w.TimeIntegration(msh, pbl, solScheme)
```


### 4. Fix MPI issues
When running in parallel, it tended to hang up at the very beginning due to the lack of an MPI barrier in `utilities.py`. That is solved.

Furthermore, it used to have some issues when sending and receiving from the master node in `interpolator.py`. Now it receives for the master _before_ sending the data to the others. There is probably a better way to handle this I assume, but for the moment it works.