### PR TITLE
Flow compatibility update

### DIFF
--- a/tests/Flow_Metafor/staticAgard_fluid.py
+++ b/tests/Flow_Metafor/staticAgard_fluid.py
@@ -40,6 +40,7 @@ def getParams():
     p['y_ref'] = 0. # Reference point for moment computation (y)
     p['z_ref'] = 0. # Reference point for moment computation (z)
     # Numerical
+    p['LSolver'] = 'Pardiso' # Linear solver (Pardiso, GMRES, MUMPS or SparseLU)
     p['NSolver'] = 'Newton' # Noninear solver type (Picard or Newton)
     p['Rel_tol'] = 1e-6 # Relative tolerance on solver residual
     p['Abs_tol'] = 1e-8 # Absolute tolerance on solver residual

--- a/tests/Flow_Metafor/staticDiamond_fluid.py
+++ b/tests/Flow_Metafor/staticDiamond_fluid.py
@@ -31,6 +31,7 @@ def getParams():
     p['y_ref'] = 0. # Reference point for moment computation (y)
     p['z_ref'] = 0. # Reference point for moment computation (z)
     # Numerical
+    p['LSolver'] = 'Pardiso' # Linear solver (Pardiso, GMRES, MUMPS or SparseLU)
     p['NSolver'] = 'Newton' # Noninear solver type (Picard or Newton)
     p['Rel_tol'] = 1e-6 # Relative tolerance on solver residual
     p['Abs_tol'] = 1e-8 # Absolute tolerance on solver residual

--- a/tests/Flow_Modal/staticAgard_fluid.py
+++ b/tests/Flow_Modal/staticAgard_fluid.py
@@ -40,6 +40,10 @@ def getParams():
     p['y_ref'] = 0. # Reference point for moment computation (y)
     p['z_ref'] = 0. # Reference point for moment computation (z)
     # Numerical
+    p['LSolver'] = 'GMRES' # Linear solver (Pardiso, GMRES, MUMPS or SparseLU)
+    p['G_fill'] = 2 # Fill-in factor for GMRES preconditioner
+    p['G_tol'] = 1e-5 # Tolerance for GMRES
+    p['G_restart'] = 50 # Restart for GMRES
     p['NSolver'] = 'Newton' # Noninear solver type (Picard or Newton)
     p['Rel_tol'] = 1e-6 # Relative tolerance on solver residual
     p['Abs_tol'] = 1e-8 # Absolute tolerance on solver residual

--- a/tests/Flow_RBM/staticNaca_fluid.py
+++ b/tests/Flow_RBM/staticNaca_fluid.py
@@ -33,6 +33,7 @@ def getParams():
     p['y_ref'] = 0. # Reference point for moment computation (y)
     p['z_ref'] = 0. # Reference point for moment computation (z)
     # Numerical
+    p['LSolver'] = 'Pardiso' # Linear solver (Pardiso, GMRES, MUMPS or SparseLU)
     p['NSolver'] = 'Newton' # Noninear solver type (Picard or Newton)
     p['Rel_tol'] = 1e-6 # Relative tolerance on solver residual
     p['Abs_tol'] = 1e-8 # Absolute tolerance on solver residual


### PR DESCRIPTION
## Context
This PR updates the interface and test cases of flow with the [latest developments](https://gitlab.uliege.be/am-dept/waves/merge_requests/53). CUPyDO v1.2.3 will be compatible with [waves v1.9](https://gitlab.uliege.be/am-dept/waves/-/tags/v1.9)

## Changes
- Change getters to be compatible with Eigen 
- Add linear (inner) solver input
- Add angle of sideslip input

## Tests
Passed on gaston (debian 9.12, python 2.7.15)